### PR TITLE
Introduce dependency injection, HttpClientFactory, and resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Twitch EventSub Websocket
 <p align="center">
-  <a href="https://www.nuget.org/packages/Twitch.EventSub.Websocket/2.2.0" target="_blank">
+  <a href="https://www.nuget.org/packages/Twitch.EventSub.Websocket/" target="_blank">
     <img src="https://img.shields.io/nuget/v/Twitch.EventSub.Websocket.svg?label=NuGet%20v" alt="NuGet version" style="max-height:300px;" />
     <img src="https://img.shields.io/nuget/dt/Twitch.EventSub.Websocket.svg?label=Downloads" alt="NuGet downloads" style="max-height:300px;" />
   </a>
-  <img src="https://img.shields.io/badge/Platform-.NET%2010-orange.svg" style="max-height: 300px;" alt=".NET 9" />
+  <img src="https://img.shields.io/badge/Platform-.NET%2010-orange.svg" style="max-height: 300px;" alt=".NET 10" />
   <img src="https://img.shields.io/github/license/GimliCZ/TwitchEventSub_Websocket" alt="License" />
   <br />
   <img src="https://img.shields.io/github/issues/GimliCZ/TwitchEventSub_Websocket" alt="Issues" />
@@ -14,50 +14,146 @@
 </p>
 
 # About
-* Handles multiple user communications with Twitch Eventsub via websocket 
+* Handles multiple user communications with Twitch EventSub via websocket
 * For more information on Twitch EventSub, refer to the [Twitch EventSub Documentation](https://dev.twitch.tv/docs/eventsub/).
 
-## Implementation
-* **Client Id** is identifier of your application
-* **User Id** is identifier of twitch user
-* **AccessToken** is token requested via bearer token of user
-* TwitchEventSub Library contains set of enums **SubscriptionType** which are setting contens of list of subscriptions
+---
 
-#### INITIALIZATION
+## Migrating from v2 to v3
+
+Version 3.0.0 introduces **Dependency Injection** as the primary setup path and replaces static API classes with injectable singletons. The following breaking changes require action.
+
+### 1. Constructor — `EventSubClient` no longer accepts `clientId` directly
+
 ```csharp
-EventSubClient(ClientId, logger);
+// v2
+var client = new EventSubClient("your-client-id", logger);
+
+// v3 — use DI (see Setup below), or supply options manually
+var client = new EventSubClient(
+    Options.Create(new EventSubClientOptions { ClientId = "your-client-id" }),
+    logger,
+    twitchApi);
 ```
+
+### 2. `TwitchApi` and `TwitchApiConduit` are no longer static
+
+If you called these classes directly:
+
+```csharp
+// v2
+await TwitchApi.SubscribeAsync(...);
+await TwitchApiConduit.ConduitCreatorAsync(...);
+
+// v3 — resolve from DI or construct with IHttpClientFactory
+var api = new TwitchApi(httpClientFactory);
+await api.SubscribeAsync(...);
+```
+
+In practice, you should not need to call these directly — `IEventSubClient` covers all normal usage.
+
+### 3. DI registration replaces manual construction
+
+```csharp
+// v2
+services.AddSingleton<IEventSubClient>(new EventSubClient("client-id", logger));
+
+// v3
+services.AddTwitchEventSub(options => options.ClientId = "your-client-id");
+```
+
+---
+
+## Setup (v3)
+
+### Quick start — single line DI registration
+
+```csharp
+// Program.cs / Startup.cs
+services.AddTwitchEventSub(options =>
+{
+    options.ClientId = "your-client-id";
+});
+```
+
+This registers:
+- Two named `HttpClient` instances (`EventSubWebsocketTwitchApi`, `EventSubWebsocketTwitchApiConduit`) with standard resilience pipelines (retry, circuit breaker, timeout) and telemetry enrichment
+- `TwitchApi` and `TwitchApiConduit` as singletons
+- `IEventSubClient` as a singleton
+- Logging if not already registered
+
+### Advanced — custom HttpClient configuration
+
+Use this when you need to configure the HTTP clients yourself (custom timeouts, proxy, etc.) before registering the client.
+
+```csharp
+services.Configure<EventSubClientOptions>(o => o.ClientId = "your-client-id");
+
+services.AddHttpClient(HttpClientNames.TwitchApi, client =>
+{
+    client.Timeout = TimeSpan.FromSeconds(60);
+})
+.AddStandardResilienceHandler(options =>
+{
+    options.Retry.MaxRetryAttempts = 5;
+});
+
+services.AddHttpClient(HttpClientNames.TwitchApiConduit);
+
+services.AddSingleton<TwitchApi>();
+services.AddSingleton<TwitchApiConduit>();
+services.AddTwitchEventSubClient();
+```
+
+The named client name constants are available on `HttpClientNames`:
+
+```csharp
+HttpClientNames.TwitchApi          // "EventSubWebsocketTwitchApi"
+HttpClientNames.TwitchApiConduit   // "EventSubWebsocketTwitchApiConduit"
+```
+
+---
+
+## Implementation
+
+* **Client Id** is the identifier of your Twitch application
+* **User Id** is the identifier of a Twitch user
+* **AccessToken** is a bearer token obtained for the user
+
+`IEventSubClient` is the primary interface — inject it wherever you need it.
+
 #### SETUP
 ```csharp
-public async Task<bool> SetupAsync(string UserId)
+public async Task<bool> SetupAsync(string userId)
 {
     var listOfSubs = new List<SubscriptionType>
     {
-        // Add requested subscriptions
         SubscriptionType.ChannelFollow
     };
     _listOfSubs = listOfSubs;
 
     var resultAdd = await _eventSubClient.AddUserAsync(
-        UserId,
+        userId,
         GetApiToken(),
-        _listOfSubs).ConfigureAwait(false);
+        _listOfSubs,
+        allowRecovery: true).ConfigureAwait(false);
 
-    if (resultAdd) 
-    { 
-        SetupEvents();
+    if (resultAdd)
+    {
+        SetupEvents(userId);
     }
     return resultAdd;
 }
 ```
+
 #### EVENT SUBSCRIPTIONS
 ```csharp
-private void SetupEvents()
+private void SetupEvents(string userId)
 {
-    var provider = _eventSubClient[_eventSubUserId];
+    var provider = _eventSubClient[userId];
     if (provider == null)
     {
-        _logger.LogError("EventSub Provider returned null for user {UserId}", _eventSubUserId);
+        _logger.LogError("EventSub Provider returned null for user {UserId}", userId);
         return;
     }
 
@@ -69,77 +165,81 @@ private void SetupEvents()
     provider.OnUnexpectedConnectionTermination += EventSubClientOnUnexpectedConnectionTermination;
 
 #if DEBUG
-    // Print RAW messages only during DEBUG
     provider.OnRawMessageAsync -= EventSubClientOnRawMessageAsync;
     provider.OnRawMessageAsync += EventSubClientOnRawMessageAsync;
 #endif
 }
 ```
 
-#### START FUNCTION
+#### START
 ```csharp
-await _eventSubClient.StartAsync(ownerId).ConfigureAwait(false);
+await _eventSubClient.StartAsync(userId).ConfigureAwait(false);
 ```
 
-#### STOP FUNCTION
+#### STOP
 ```csharp
-await _eventSubClient.StopAsync(_eventSubUserId).ConfigureAwait(false);
+await _eventSubClient.StopAsync(userId).ConfigureAwait(false);
 ```
 
 #### AUTHORIZATION
-* **EventSub does not provide refresh token capabilities. You have to provide your own.**
-* To function properly, you are required to subscribe to **EventSubClientOnRefreshToken** event in order to refresh token
+* EventSub does not provide token refresh capabilities — you must implement your own.
+* Subscribe to `OnRefreshTokenAsync` to be notified when a token refresh is needed.
+
 ```csharp
 provider.OnRefreshTokenAsync -= EventSubClientOnRefreshTokenAsync;
 provider.OnRefreshTokenAsync += EventSubClientOnRefreshTokenAsync;
 ```
-* Then run your token refreshing function and pass new token
+
 ```csharp
-private async Task EventSubClientOnRefreshTokenAsync(object sender, InvalidAccessTokenException e)
+private async Task EventSubClientOnRefreshTokenAsync(object sender, RefreshRequestArgs e)
 {
-    _logger.LogInformation("Event Sub Attempting to refresh access token");
+    _logger.LogInformation("EventSub requesting token refresh for user {UserId}", e.UserId);
     _eventSubClient.UpdateUser(
-        UserId,
-        newAccessToken(),
-        _listOfSubs
-    );
+        e.UserId,
+        await GetNewAccessTokenAsync(),
+        _listOfSubs);
 }
 ```
+
 #### RECOVERY
-* During processing of users you may listen to **IsConnected** flag and **EventSubClientOnFollowEventAsync** to make sure client is working.
-* On unexpected client can happen during stream termination, so make sure you detect it and stop client before you get external disconnect.
-* Then you can do two things, You may completely remove entire user object. Or you may try to Start it again (Works only in disposed state). 
-``` csharp
-private async void RecoveryRoutineAsync()
+Listen to `IsConnected` and `OnUnexpectedConnectionTermination` to detect failures and recover.
+
+```csharp
+private async void RecoveryRoutineAsync(string userId)
 {
     try
     {
-        if (_eventSubClient.IsConnected(_eventSubUserId))
+        if (_eventSubClient.IsConnected(userId))
         {
-            _logger.LogDebug("EventSubClient is already connected, skip recovery procedure");
+            _logger.LogDebug("EventSubClient is already connected, skipping recovery");
             return;
         }
 
-        _eventSubClient[_eventSubUserId].OnRefreshTokenAsync -= EventSubClientOnRefreshTokenAsync;
-        _eventSubClient[_eventSubUserId].OnFollowEventAsync -= EventSubClientOnFollowEventAsync;
-        _eventSubClient[_eventSubUserId].OnUnexpectedConnectionTermination -= EventSubClientOnUnexpectedConnectionTermination;
-        _eventSubClient[_eventSubUserId].OnRawMessageAsync -= EventSubClientOnRawMessageAsync;
-
-        var deletionCheck = await _eventSubClient.DeleteUserAsync(_eventSubUserId);
-        if (!deletionCheck)
+        var provider = _eventSubClient[userId];
+        if (provider != null)
         {
-            _logger.LogWarning("EventSub user was NOT gracefully terminated during reconnect attempt");
+            provider.OnRefreshTokenAsync -= EventSubClientOnRefreshTokenAsync;
+            provider.OnFollowEventAsync -= EventSubClientOnFollowEventAsync;
+            provider.OnUnexpectedConnectionTermination -= EventSubClientOnUnexpectedConnectionTermination;
+            provider.OnRawMessageAsync -= EventSubClientOnRawMessageAsync;
         }
 
-        await SetupAsync(_eventSubUserId).ConfigureAwait(false);
-        await _eventSubClient.StartAsync(ownerId).ConfigureAwait(false);
+        var deleted = await _eventSubClient.DeleteUserAsync(userId);
+        if (!deleted)
+        {
+            _logger.LogWarning("EventSub user was not gracefully terminated during recovery");
+        }
+
+        await SetupAsync(userId).ConfigureAwait(false);
+        await _eventSubClient.StartAsync(userId).ConfigureAwait(false);
     }
     catch (Exception ex)
     {
-        _logger.LogError(ex, "EventSubClientRecoveryRoutineAsync failed");
+        _logger.LogError(ex, "EventSub recovery routine failed");
     }
 }
 ```
+
 ## STATE DIAGRAM
 ![Alt text](https://github.com/GimliCZ/TwitchEventSub_Websocket/blob/feature/ReworkAndConduit/graphviz.png)
 

--- a/Twitch EventSub library/API/TwitchApi.cs
+++ b/Twitch EventSub library/API/TwitchApi.cs
@@ -10,11 +10,18 @@ using Twitch.EventSub.CoreFunctions;
 
 namespace Twitch.EventSub.API
 {
-    public static class TwitchApi
+    public class TwitchApi
     {
         private const string BaseUrl = "https://api.twitch.tv/helix/eventsub/subscriptions";
 
         private const string ValidateUrl = "https://id.twitch.tv/oauth2/validate";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public TwitchApi(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
 
         /// <summary>
         /// Function sends filled CreateSubscriptionRequest to twitch for processing
@@ -27,9 +34,9 @@ namespace Twitch.EventSub.API
         /// <returns>True on success, false on failure</returns>
         /// <exception cref="InvalidAccessTokenException"></exception>
         /// <exception cref="Exception">This state means that accessToken is not set up properly for given request</exception>
-        public static async Task<bool> SubscribeAsync(string? clientId, string? accessToken, CreateSubscriptionRequest request, CancellationTokenSource clSource, ILogger logger, string? url = null)
+        public async Task<bool> SubscribeAsync(string? clientId, string? accessToken, CreateSubscriptionRequest request, CancellationTokenSource clSource, ILogger logger, string? url = null)
         {
-            using (var httpClient = new HttpClient())
+            var httpClient = _httpClientFactory.CreateClient(HttpClientNames.TwitchApi);
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 httpClient.DefaultRequestHeaders.Add("Client-Id", clientId);
@@ -69,9 +76,9 @@ namespace Twitch.EventSub.API
         /// <param name="subscriptionId"></param>
         /// <returns>True on success, false on failure</returns>
         /// <exception cref="InvalidAccessTokenException"></exception>
-        public static async Task<bool> UnSubscribeAsync(string? clientId, string? accessToken, string subscriptionId, CancellationTokenSource clSource, ILogger logger, string? url = null)
+        public async Task<bool> UnSubscribeAsync(string? clientId, string? accessToken, string subscriptionId, CancellationTokenSource clSource, ILogger logger, string? url = null)
         {
-            using (var httpClient = new HttpClient())
+            var httpClient = _httpClientFactory.CreateClient(HttpClientNames.TwitchApi);
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 httpClient.DefaultRequestHeaders.Add("Client-Id", clientId);
@@ -107,11 +114,11 @@ namespace Twitch.EventSub.API
         /// <param name="after"></param>
         /// <returns cref="GetSubscriptionsResponse"> Provides segment of subscriptions, content MAY BE NULL</returns>
         /// <exception cref="InvalidAccessTokenException"></exception>
-        private static async Task<GetSubscriptionsResponse?> GetSubscriptionsAsync(string? clientId, string? accessToken, SubscriptionStatusTypes statusSelector, CancellationTokenSource clSource, ILogger logger, string? after = null, string? url = null)
+        private async Task<GetSubscriptionsResponse?> GetSubscriptionsAsync(string? clientId, string? accessToken, SubscriptionStatusTypes statusSelector, CancellationTokenSource clSource, ILogger logger, string? after = null, string? url = null)
         {
             var status = StatusProvider.GetStatusString(statusSelector);
 
-            using (var httpClient = new HttpClient())
+            var httpClient = _httpClientFactory.CreateClient(HttpClientNames.TwitchApi);
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 httpClient.DefaultRequestHeaders.Add("Client-Id", clientId);
@@ -158,7 +165,7 @@ namespace Twitch.EventSub.API
         /// <param name="statusSelector"></param>
         /// <returns> list of subscriptions</returns>
         /// <exception cref="InvalidAccessTokenException">May provide exception from GetSubscriptionsAsync</exception>
-        public static async Task<List<GetSubscriptionsResponse>> GetAllSubscriptionsAsync(string? clientId, string? accessToken, CancellationTokenSource clSource, ILogger logger, SubscriptionStatusTypes statusSelector = SubscriptionStatusTypes.Enabled, string? url = null)
+        public async Task<List<GetSubscriptionsResponse>> GetAllSubscriptionsAsync(string? clientId, string? accessToken, CancellationTokenSource clSource, ILogger logger, SubscriptionStatusTypes statusSelector = SubscriptionStatusTypes.Enabled, string? url = null)
         {
             var allSubscriptions = new List<GetSubscriptionsResponse>();
             string? afterCursor = null;
@@ -203,9 +210,9 @@ namespace Twitch.EventSub.API
         /// <param name="logger">ILogger for logging.</param>
         /// <returns>True if the token is valid, false if not.</returns>
         /// <exception cref="InvalidAccessTokenException"></exception>
-        public static async Task<bool> ValidateTokenAsync(string? accessToken, CancellationTokenSource clSource, ILogger logger, string? url = null)
+        public async Task<bool> ValidateTokenAsync(string? accessToken, CancellationTokenSource clSource, ILogger logger, string? url = null)
         {
-            using (var httpClient = new HttpClient())
+            var httpClient = _httpClientFactory.CreateClient(HttpClientNames.TwitchApi);
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("OAuth", accessToken);
                 try

--- a/Twitch EventSub library/APIConduit/TwitchConduitApi.cs
+++ b/Twitch EventSub library/APIConduit/TwitchConduitApi.cs
@@ -7,18 +7,27 @@ using Twitch.EventSub.API.Enums;
 using Twitch.EventSub.API.Models;
 using Twitch.EventSub.API.Providers;
 using Twitch.EventSub.APIConduit.Models.Requests;
+using Twitch.EventSub.CoreFunctions;
 using Twitch.EventSub.APIConduit.Models.Responses;
 using Twitch.EventSub.APIConduit.Models.Shared;
 
 namespace Twitch.EventSub.APIConduit
 {
-    public static class TwitchApiConduit
+    public class TwitchApiConduit
     {
         private const string ConduitUrl = "https://api.twitch.tv/helix/eventsub/conduits";
         private const string ConduitShardsUrl = "https://api.twitch.tv/helix/eventsub/conduits/shards";
-        public static async Task<ConduitCreateResponse> ConduitCreatorAsync(string accessToken, string clientId, CancellationTokenSource clSource, ILogger logger, int inicialSize = 1)
+
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public TwitchApiConduit(IHttpClientFactory httpClientFactory)
         {
-            using (var httpClient = new HttpClient())
+            _httpClientFactory = httpClientFactory;
+        }
+
+        public async Task<ConduitCreateResponse> ConduitCreatorAsync(string accessToken, string clientId, CancellationTokenSource clSource, ILogger logger, int inicialSize = 1)
+        {
+            var httpClient = _httpClientFactory.CreateClient(HttpClientNames.TwitchApiConduit);
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 httpClient.DefaultRequestHeaders.Add("Client-Id", clientId);
@@ -53,9 +62,9 @@ namespace Twitch.EventSub.APIConduit
             }
         }
 
-        public static async Task<ConduitUpdateResponse> ConduitUpdateAsync(string accessToken, string clientId, CancellationTokenSource clSource, ILogger logger, string conduitId, int size)
+        public async Task<ConduitUpdateResponse> ConduitUpdateAsync(string accessToken, string clientId, CancellationTokenSource clSource, ILogger logger, string conduitId, int size)
         {
-            using (var httpClient = new HttpClient())
+            var httpClient = _httpClientFactory.CreateClient(HttpClientNames.TwitchApiConduit);
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 httpClient.DefaultRequestHeaders.Add("Client-Id", clientId);
@@ -87,9 +96,9 @@ namespace Twitch.EventSub.APIConduit
                 }
             }
         }
-        public static async Task<bool> ConduitDeleteAsync(string accessToken, string clientId, CancellationTokenSource clSource, ILogger logger, string conduitId)
+        public async Task<bool> ConduitDeleteAsync(string accessToken, string clientId, CancellationTokenSource clSource, ILogger logger, string conduitId)
         {
-            using (var httpClient = new HttpClient())
+            var httpClient = _httpClientFactory.CreateClient(HttpClientNames.TwitchApiConduit);
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 httpClient.DefaultRequestHeaders.Add("Client-Id", clientId);
@@ -120,9 +129,9 @@ namespace Twitch.EventSub.APIConduit
                 }
             }
         }
-        public static async Task<ConduitGetShardsResponse> ConduitGetShardsAsync(string accessToken, string clientId, CancellationTokenSource clSource, ILogger logger, string conduitId, SubscriptionStatusTypes status = SubscriptionStatusTypes.Empty, string after = null)
+        public async Task<ConduitGetShardsResponse> ConduitGetShardsAsync(string accessToken, string clientId, CancellationTokenSource clSource, ILogger logger, string conduitId, SubscriptionStatusTypes status = SubscriptionStatusTypes.Empty, string after = null)
         {
-            using (var httpClient = new HttpClient())
+            var httpClient = _httpClientFactory.CreateClient(HttpClientNames.TwitchApiConduit);
             {
                 httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
                 httpClient.DefaultRequestHeaders.Add("Client-Id", clientId);
@@ -161,7 +170,7 @@ namespace Twitch.EventSub.APIConduit
                 }
             }
         }
-        public static async Task<List<ConduitShard>> GetAllConduitGetShardsAsync(string clientId, string accessToken, string conduitId, CancellationTokenSource clSource, ILogger logger, SubscriptionStatusTypes statusSelector = SubscriptionStatusTypes.Enabled)
+        public async Task<List<ConduitShard>> GetAllConduitGetShardsAsync(string clientId, string accessToken, string conduitId, CancellationTokenSource clSource, ILogger logger, SubscriptionStatusTypes statusSelector = SubscriptionStatusTypes.Enabled)
         {
             var allSubscriptions = new List<ConduitShard>();
             string? afterCursor = null;

--- a/Twitch EventSub library/CoreFunctions/HttpClientNames.cs
+++ b/Twitch EventSub library/CoreFunctions/HttpClientNames.cs
@@ -1,0 +1,8 @@
+namespace Twitch.EventSub.CoreFunctions
+{
+    public static class HttpClientNames
+    {
+        public const string TwitchApi = "EventSubWebsocketTwitchApi";
+        public const string TwitchApiConduit = "EventSubWebsocketTwitchApiConduit";
+    }
+}

--- a/Twitch EventSub library/EventSubClient.cs
+++ b/Twitch EventSub library/EventSubClient.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
+using Twitch.EventSub.API;
 using Twitch.EventSub.API.Enums;
 using Twitch.EventSub.CoreFunctions;
 using Twitch.EventSub.Interfaces;
@@ -16,18 +18,21 @@ namespace Twitch.EventSub
         private readonly string _clientId;
         private readonly ConcurrentDictionary<string, EventProvider> _eventDictionary;
         private readonly ILogger _logger;
+        private readonly TwitchApi _twitchApi;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventSubClient"/> class.
         /// </summary>
-        /// <param name="clientId">The client ID.</param>
+        /// <param name="options">Configuration options containing the client ID.</param>
         /// <param name="logger">The logger instance.</param>
-        public EventSubClient(string clientId, ILogger<EventSubClient> logger)
+        /// <param name="twitchApi">The TwitchApi singleton instance.</param>
+        public EventSubClient(IOptions<EventSubClientOptions> options, ILogger<EventSubClient> logger, TwitchApi twitchApi)
         {
-            _clientId = clientId;
+            _clientId = options.Value.ClientId;
             _eventDictionary = new ConcurrentDictionary<string, EventProvider>();
             _logger = logger;
-            _logger.LogDebug("EventSubClient instantiated with clientId: {ClientId}", clientId);
+            _twitchApi = twitchApi;
+            _logger.LogDebug("EventSubClient instantiated with clientId: {ClientId}", _clientId);
         }
 
         /// <summary>
@@ -73,7 +78,7 @@ namespace Twitch.EventSub
                 return false;
             }
 
-            var eventProvider = new EventProvider(userId, accessToken, listOfSubs, _clientId, _logger, allowRecovery);
+            var eventProvider = new EventProvider(userId, accessToken, listOfSubs, _clientId, _logger, allowRecovery, _twitchApi);
             _logger.LogDebug("Attempting to add user");
             return _eventDictionary.TryAdd(userId, eventProvider);
         }

--- a/Twitch EventSub library/EventSubClientOptions.cs
+++ b/Twitch EventSub library/EventSubClientOptions.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.Options;
+
+namespace Twitch.EventSub
+{
+    public record EventSubClientOptions
+    {
+        /// <summary>
+        /// Your Twitch application client ID.
+        /// </summary>
+        public string ClientId { get; set; } = string.Empty;
+    }
+}

--- a/Twitch EventSub library/ServiceCollectionExtensions.cs
+++ b/Twitch EventSub library/ServiceCollectionExtensions.cs
@@ -1,0 +1,90 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http.Resilience;
+using Microsoft.Extensions.Logging;
+using Twitch.EventSub.API;
+using Twitch.EventSub.APIConduit;
+using Twitch.EventSub.CoreFunctions;
+
+namespace Twitch.EventSub
+{
+    public static class ServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Registers all TwitchEventSub services: named HttpClients with resilience and enrichment,
+        /// API singletons, logging (if not already registered), and <see cref="IEventSubClient"/>.
+        /// </summary>
+        /// <param name="services">The service collection.</param>
+        /// <param name="configure">Action to configure <see cref="EventSubClientOptions"/> (e.g. ClientId).</param>
+        public static IServiceCollection AddTwitchEventSub(
+            this IServiceCollection services,
+            Action<EventSubClientOptions> configure)
+        {
+            services.Configure(configure);
+            services.AddTwitchEventSubHttpClients();
+            services.AddTwitchEventSubClient();
+            return services;
+        }
+
+        /// <summary>
+        /// Registers the named HttpClients with standard resilience pipelines and enrichment,
+        /// and API singletons required by TwitchEventSub.
+        /// Named clients: <see cref="HttpClientNames.TwitchApi"/> and <see cref="HttpClientNames.TwitchApiConduit"/>.
+        /// Use this when you want to configure the HttpClients yourself before calling
+        /// <see cref="AddTwitchEventSubClient"/>.
+        /// </summary>
+        public static IServiceCollection AddTwitchEventSubHttpClients(this IServiceCollection services)
+        {
+            services.AddResilienceEnricher();
+
+            services.AddHttpClient(HttpClientNames.TwitchApi, client =>
+            {
+                client.DefaultRequestHeaders.Add("Accept", "application/json");
+            })
+            .AddStandardResilienceHandler(options =>
+            {
+                // Twitch EventSub API — tune retry/timeout to respect Twitch rate limits
+                options.Retry.MaxRetryAttempts = 3;
+                options.Retry.Delay = TimeSpan.FromSeconds(2);
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(30);
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(10);
+            });
+
+            services.AddHttpClient(HttpClientNames.TwitchApiConduit, client =>
+            {
+                client.DefaultRequestHeaders.Add("Accept", "application/json");
+            })
+            .AddStandardResilienceHandler(options =>
+            {
+                options.Retry.MaxRetryAttempts = 3;
+                options.Retry.Delay = TimeSpan.FromSeconds(2);
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromSeconds(30);
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(10);
+            });
+
+            services.AddSingleton<TwitchApi>();
+            services.AddSingleton<TwitchApiConduit>();
+
+            return services;
+        }
+
+        /// <summary>
+        /// Registers only the <see cref="IEventSubClient"/> singleton.
+        /// Registers logging if <see cref="ILoggerFactory"/> has not already been registered.
+        /// Use this when you have already registered named HttpClients and API singletons
+        /// via <see cref="AddTwitchEventSubHttpClients"/> or your own configuration.
+        /// Requires <see cref="EventSubClientOptions"/> to be configured via
+        /// <c>services.Configure&lt;EventSubClientOptions&gt;(...)</c> before calling this.
+        /// </summary>
+        public static IServiceCollection AddTwitchEventSubClient(this IServiceCollection services)
+        {
+            if (!services.Any(d => d.ServiceType == typeof(ILoggerFactory)))
+            {
+                services.AddLogging();
+            }
+
+            services.AddSingleton<IEventSubClient, EventSubClient>();
+
+            return services;
+        }
+    }
+}

--- a/Twitch EventSub library/Twitch.EventSub_Websocket.csproj
+++ b/Twitch EventSub library/Twitch.EventSub_Websocket.csproj
@@ -16,13 +16,14 @@
         <RepositoryUrl>https://github.com/GimliCZ/EventSub-Websocket-Twitch/</RepositoryUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-        <Version>2.2.7</Version>
+        <Version>3.0.0</Version>
         <RepositoryType>git</RepositoryType>
         <LangVersion>14</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.4" />
         <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.14.15" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
         <PackageReference Include="Stateless" Version="5.20.0" />

--- a/Twitch EventSub library/User/EventProvider.cs
+++ b/Twitch EventSub library/User/EventProvider.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Twitch.EventSub.API;
 using Twitch.EventSub.API.Enums;
 using Twitch.EventSub.API.Extensions;
 using Twitch.EventSub.API.Models;
@@ -45,6 +46,7 @@ namespace Twitch.EventSub.User
         private UserSequencer _userSequencer;
         private readonly Timer _recoveryTimer;
         private readonly bool _allowRecovery;
+        private readonly TwitchApi _twitchApi;
         private string? _testingApiUrl;
         private string? _testingWebsocketUrl;
 
@@ -54,7 +56,8 @@ namespace Twitch.EventSub.User
             List<SubscriptionTypes> listOfSubs,
             string clientId,
             ILogger logger,
-            bool allowRecovery)
+            bool allowRecovery,
+            TwitchApi twitchApi)
         {
             ArgumentException.ThrowIfNullOrWhiteSpace(userId, nameof(userId));
             ArgumentException.ThrowIfNullOrWhiteSpace(accessToken, nameof(accessToken));
@@ -68,6 +71,7 @@ namespace Twitch.EventSub.User
             _logger = logger;
             _recoveryTimer = new(_ => OnRecoveryTimerEnlapsedAsync(), null, Timeout.Infinite, Timeout.Infinite);
             _allowRecovery = allowRecovery;
+            _twitchApi = twitchApi;
             Create();
         }
 
@@ -121,7 +125,7 @@ namespace Twitch.EventSub.User
                     Condition = new Condition()
                 }.SetSubscriptionType(type, _userId));
             }
-            _userSequencer = new UserSequencer(_userId, _accessToken, listOfRequests, _clientId, _logger, testApiUrl, testWebsocketUrl);
+            _userSequencer = new UserSequencer(_userId, _accessToken, listOfRequests, _clientId, _logger, _twitchApi, testApiUrl, testWebsocketUrl);
 
             _userSequencer.AccessTokenRequestedEvent += AccessTokenRequestedEventAsync;
             _userSequencer.OnRawMessageRecievedAsync += OnRawMessageReceivedAsync;

--- a/Twitch EventSub library/User/SubscriptionManager.cs
+++ b/Twitch EventSub library/User/SubscriptionManager.cs
@@ -12,10 +12,12 @@ namespace Twitch.EventSub.User
     public class SubscriptionManager
     {
         private readonly string _url;
+        private readonly TwitchApi _twitchApi;
 
-        public SubscriptionManager(string url = null)
+        public SubscriptionManager(TwitchApi twitchApi, string url = null)
         {
             _url = url;
+            _twitchApi = twitchApi;
         }
 
         /// <summary>
@@ -202,7 +204,7 @@ namespace Twitch.EventSub.User
             ILogger logger,
             CancellationTokenSource clSource)
         {
-            Task<bool> TryValidateAsync() => TwitchApi.ValidateTokenAsync(accessToken, clSource, logger, _url);
+            Task<bool> TryValidateAsync() => _twitchApi.ValidateTokenAsync(accessToken, clSource, logger, _url);
             return TryFuncAsync(TryValidateAsync, logger, userId);
         }
 
@@ -224,7 +226,7 @@ namespace Twitch.EventSub.User
             ILogger logger,
             CancellationTokenSource clSource)
         {
-            Task<bool> TrySubscribeAsync() => TwitchApi.SubscribeAsync(clientId, accessToken, create, clSource, logger, _url);
+            Task<bool> TrySubscribeAsync() => _twitchApi.SubscribeAsync(clientId, accessToken, create, clSource, logger, _url);
             return TryFuncAsync(TrySubscribeAsync, logger, userId);
         }
 
@@ -240,7 +242,7 @@ namespace Twitch.EventSub.User
         /// <returns>Returns true, if unsubscribe was successfull</returns>
         private Task<bool> ApiTryUnSubscribeAsync(string clientId, string accessToken, string subId, string userId, ILogger logger, CancellationTokenSource clSource)
         {
-            Task<bool> TryUnSubscribeAsync() => TwitchApi.UnSubscribeAsync(clientId, accessToken, subId, clSource, logger, _url);
+            Task<bool> TryUnSubscribeAsync() => _twitchApi.UnSubscribeAsync(clientId, accessToken, subId, clSource, logger, _url);
             return TryFuncAsync(TryUnSubscribeAsync, logger, userId);
         }
 
@@ -256,7 +258,7 @@ namespace Twitch.EventSub.User
         /// <returns>Returns all subscriptions requested by filter, on fail returns null</returns>
         private Task<List<GetSubscriptionsResponse>?> ApiTryGetAllSubscriptionsAsync(string clientId, string accessToken, string userId, CancellationTokenSource clSource, ILogger logger, SubscriptionStatusTypes statusSelector)
         {
-            Task<List<GetSubscriptionsResponse>> TryGetAllSubscriptionsAsync() => TwitchApi.GetAllSubscriptionsAsync(clientId, accessToken, clSource, logger, statusSelector, _url);
+            Task<List<GetSubscriptionsResponse>> TryGetAllSubscriptionsAsync() => _twitchApi.GetAllSubscriptionsAsync(clientId, accessToken, clSource, logger, statusSelector, _url);
             return TryFuncAsync(TryGetAllSubscriptionsAsync, logger, userId);
         }
 

--- a/Twitch EventSub library/User/UserSequencer.cs
+++ b/Twitch EventSub library/User/UserSequencer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Threading;
+using Twitch.EventSub.API;
 using Newtonsoft.Json;
 using System.Net.WebSockets;
 using System.Reactive.Linq;
@@ -50,13 +51,13 @@ namespace Twitch.EventSub.User
         /// <param name="requestedSubscriptions">List of requested subscriptions.</param>
         /// <param name="clientId">Client ID.</param>
         /// <param name="logger">Logger instance.</param>
-        public UserSequencer(string id, string access, List<CreateSubscriptionRequest> requestedSubscriptions, string clientId, ILogger logger, string apiTestingUrl = null, string socketTestingUrl = null) : base(id, access, requestedSubscriptions, socketTestingUrl)
+        public UserSequencer(string id, string access, List<CreateSubscriptionRequest> requestedSubscriptions, string clientId, ILogger logger, TwitchApi twitchApi, string apiTestingUrl = null, string socketTestingUrl = null) : base(id, access, requestedSubscriptions, socketTestingUrl)
         {
             _logger = logger;
             ClientId = clientId;
             _watchdog = new Watchdog(logger);
             _replayProtection = new ReplayProtection(10);
-            _subscriptionManager = new SubscriptionManager(apiTestingUrl);
+            _subscriptionManager = new SubscriptionManager(twitchApi, apiTestingUrl);
             _logger.LogDebug("[UserSequencer] Initialized with UserId: {UserId}, ClientId: {ClientId}", id, clientId);
             _managerTimer = new Timer(_ => OnManagerTimerEnlapsedAsync(), null, Timeout.Infinite, Timeout.Infinite);
             _watchdog.OnWatchdogTimeout -= OnWatchdogTimeoutAsync;


### PR DESCRIPTION
  BREAKING CHANGES:
  - TwitchApi and TwitchApiConduit converted from static to singleton instance classes; direct static calls no longer compile
  - EventSubClient constructor now accepts IOptions<EventSubClientOptions> instead of a raw string clientId parameter
  - TwitchApi singleton is now a required constructor dependency on EventSubClient

  Changes:
  - Add IHttpClientFactory support — HttpClient is no longer created per-request, eliminating socket exhaustion under load
  - Add HttpClientNames static class in CoreFunctions exposing named client constants (EventSubWebsocketTwitchApi, EventSubWebsocketTwitchApiConduit)
  - Add EventSubClientOptions record for Options-pattern configuration of ClientId
  - Add ServiceCollectionExtensions with three registration helpers: AddTwitchEventSub(Action<EventSubClientOptions>) — full one-liner AddTwitchEventSubHttpClients() — named clients + API singletons only AddTwitchEventSubClient() — IEventSubClient singleton only
  - Add Microsoft.Extensions.Http.Resilience 10.4.0 with standard resilience pipeline on both named clients (retry x3, circuit breaker, 30s total timeout, 10s per-attempt timeout) and AddResilienceEnricher for telemetry enrichment
  - Bump Microsoft.Extensions.Logging.Abstractions to 10.0.4 to satisfy resilience package transitive dependency
  - Update README: migration guide from v2, updated setup examples, correct RefreshRequestArgs type in token refresh handler, document HttpClientNames